### PR TITLE
[Fixed]トップ画面遷移先

### DIFF
--- a/app/views/homes/top.html.erb
+++ b/app/views/homes/top.html.erb
@@ -4,7 +4,7 @@
 <div class="area1">
 <ul>
   <li>
-    <%= link_to "新規登録", user_session_path, class: "header-link" %>
+    <%= link_to "新規登録", new_user_registration_path, class: "header-link" %>
   </li>
   <li>
     <%= link_to "ログイン", user_session_path, class: "header-link" %>


### PR DESCRIPTION
スマホ対応トップ画面にて新規登録ボタンの画面遷移URLに誤りがあったため訂正しました。